### PR TITLE
Refactor GaslessTokenTransfer to use deploy script

### DIFF
--- a/script/DeployERC20Permit.s.sol
+++ b/script/DeployERC20Permit.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {ERC20Permit} from "../src/ERC20Permit.sol";
+
+contract DeployERC20Permit is Script {
+    string public constant NAME = "TestToken";
+    string public constant SYMBOL = "TTK";
+    uint8 public constant DECIMALS = 18;
+
+    function deployERC20Permit() public returns (ERC20Permit) {
+        vm.startBroadcast();
+        ERC20Permit token = new ERC20Permit(NAME, SYMBOL, DECIMALS);
+        vm.stopBroadcast();
+        console2.log("ERC20Permit deployed at:", address(token));
+
+        return token;
+    }
+
+    function run() external {
+        deployERC20Permit();
+    }
+}

--- a/script/DeployGaslessToken.s.sol
+++ b/script/DeployGaslessToken.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {GaslessTokenTransfer} from "../src/GaslessTokenTransfer.sol";
+
+contract DeployGaslessTokenTransfer is Script {
+    function deployGaslessTokenTransfer() public returns (GaslessTokenTransfer) {
+        vm.startBroadcast();
+        GaslessTokenTransfer gaslessTokenTransfer = new GaslessTokenTransfer();
+        vm.stopBroadcast();
+
+        console2.log("GaslessTokenTransfer deployed at:", address(gaslessTokenTransfer));
+
+        return gaslessTokenTransfer;
+    }
+
+    function run() external {
+        deployGaslessTokenTransfer();
+    }
+}

--- a/test/GaslessTokenTransfer.t.sol
+++ b/test/GaslessTokenTransfer.t.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.20;
 import {Test, console} from "forge-std/Test.sol";
 import {GaslessTokenTransfer} from "../src/GaslessTokenTransfer.sol";
 import {ERC20Permit} from "../src/ERC20Permit.sol";
+import {DeployGaslessTokenTransfer} from "../script/DeployGaslessToken.s.sol";
+import {DeployERC20Permit} from "../script/DeployERC20Permit.s.sol";
 
 contract GaslessTokenTransferTest is Test {
     ERC20Permit private token;
@@ -19,18 +21,20 @@ contract GaslessTokenTransferTest is Test {
     function setUp() public {
         sender = vm.addr(SENDER_PRIVATE_KEY);
         receiver = address(2);
-        token = new ERC20Permit("Test", "Test", 18);
+        // token = new ERC20Permit("Test", "Test", 18);
+        DeployERC20Permit deployerERC20Permit = new DeployERC20Permit();
+        token = deployerERC20Permit.deployERC20Permit();
         token.mint(sender, AMOUNT + FEE);
-        gaslessToken = new GaslessTokenTransfer();
+        // gaslessToken = new GaslessTokenTransfer();
+        DeployGaslessTokenTransfer deployer = new DeployGaslessTokenTransfer();
+        gaslessToken = deployer.deployGaslessTokenTransfer();
     }
 
     function testValidSig() public {
         uint256 deadline = block.timestamp + 60;
 
         // Prepare permit signature
-        bytes32 permitHash = _getPermitHash(
-            sender, address(gaslessToken), AMOUNT + FEE, token.nonces(sender),  deadline
-        );
+        bytes32 permitHash = _getPermitHash(sender, address(gaslessToken), AMOUNT + FEE, token.nonces(sender), deadline);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(SENDER_PRIVATE_KEY, permitHash);
         // Execute Send
         gaslessToken.send(address(token), sender, receiver, AMOUNT, FEE, deadline, v, r, s);


### PR DESCRIPTION
refactor gaslessTokenTransfer test to use deploy script for erc20permit and gaslesstokentransfer script

![image](https://github.com/user-attachments/assets/e3714ccc-afd7-4d5d-a205-4e1d3e397027)
